### PR TITLE
Load mouse.el for using its functions

### DIFF
--- a/popup-edit-menu.el
+++ b/popup-edit-menu.el
@@ -26,6 +26,8 @@
 
 ;;; Code:
 
+(require 'mouse)
+
 ;;;###autoload
 (defgroup popup-edit-menu nil
     "Display a popup enhanced context edit menu"


### PR DESCRIPTION
This suppresses byte-compile warnings. I got following warnings on emacs 24.3.

```
popup-edit-menu.el:114:1:Warning: the following functions are not known to be defined: popup-menu,
    mouse-menu-bar-map
```